### PR TITLE
Update devspaces.yml

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_cloud_architecture_workshop_summit2023/tasks/devspaces.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cloud_architecture_workshop_summit2023/tasks/devspaces.yml
@@ -15,7 +15,7 @@
 
 - name: Wait until devspaces checluster is running
   ansible.builtin.uri:
-    url: https://devspaces.{{ r_openshift_subdomain }}/devfile-registry
+    url: https://devspaces.{{ r_openshift_subdomain }}/plugin-registry/v3/plugins/che-incubator/che-code/latest/devfile.yaml
     status_code: '200'
   register: result
   until: result.status == 200


### PR DESCRIPTION
Check if devspaces checluster is running trough plugin's devfile

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
Devspaces Validation

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
To validate despaces
instead of this - which in the new version of Devspace expects user auth (thus results in 403 than the earlier 200)
```
url: https://devspaces.{{ r_openshift_subdomain }}/devfile-registry
```
look for this which doesnt expect auth and thus results in 200

```
    url: https://devspaces.{{ r_openshift_subdomain }}/plugin-registry/v3/plugins/che-incubator/che-code/latest/devfile.yaml
```
